### PR TITLE
Feature: use existing ids

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -49,10 +49,9 @@ function search(root, expression, maxDepth) {
      */
 
     visit(root, HEADING, function (child, index, parent) {
-        var value = (child.data && child.data.hProperties && child.data.hProperties.id) ?
-            child.data.hProperties.id :
-            toString(child);
-        var id = slugs.slug(value);
+        var value = toString(child);
+        var id = child.data && child.data.hProperties && child.data.hProperties.id;
+        id = slugs.slug(id || value);
 
         if (parent !== root) {
             return;

--- a/lib/search.js
+++ b/lib/search.js
@@ -49,7 +49,7 @@ function search(root, expression, maxDepth) {
      */
 
     visit(root, HEADING, function (child, index, parent) {
-        var value = toString(child);
+        var value = (child.data && child.data.hProperties) ? child.data.hProperties.id : toString(child);
         var id = slugs.slug(value);
 
         if (parent !== root) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -49,7 +49,9 @@ function search(root, expression, maxDepth) {
      */
 
     visit(root, HEADING, function (child, index, parent) {
-        var value = (child.data && child.data.hProperties) ? child.data.hProperties.id : toString(child);
+        var value = (child.data && child.data.hProperties && child.data.hProperties.id) ?
+            child.data.hProperties.id :
+            toString(child);
         var id = slugs.slug(value);
 
         if (parent !== root) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "esmangle": "^1.0.1",
     "istanbul": "^0.4.4",
     "remark": "^8.0.0",
+    "remark-attr": "^0.6.2",
     "remark-cli": "^4.0.0",
     "remark-comment-config": "^5.0.0",
     "remark-github": "^7.0.0",

--- a/test/fixtures/normal-attr/input.md
+++ b/test/fixtures/normal-attr/input.md
@@ -1,0 +1,11 @@
+# Something
+
+## Something else
+{ #else }
+
+Text.
+
+## Something elsefi
+
+# Something also
+{ #something }

--- a/test/fixtures/normal-attr/output.json
+++ b/test/fixtures/normal-attr/output.json
@@ -1,0 +1,104 @@
+{
+  "index": null,
+  "endIndex": null,
+  "map": {
+    "type": "list",
+    "ordered": false,
+    "children": [
+      {
+        "type": "listItem",
+        "loose": true,
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "link",
+                "title": null,
+                "url": "#something",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Something"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "ordered": false,
+            "children": [
+              {
+                "type": "listItem",
+                "loose": false,
+                "children": [
+                  {
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "link",
+                        "title": null,
+                        "url": "#else",
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Something else"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "listItem",
+                "loose": false,
+                "children": [
+                  {
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "link",
+                        "title": null,
+                        "url": "#something-elsefi",
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Something elsefi"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "loose": false,
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "link",
+                "title": null,
+                "url": "#something-1",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Something also"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var remark = require('remark');
+var remarkAttr = require('remark-attr');
 var toc = require('..');
 
 var read = fs.readFileSync;
@@ -29,7 +30,7 @@ test('Fixtures', function (t) {
     }).forEach(function (fixture) {
         var filepath = join(ROOT, fixture);
         var output = JSON.parse(read(join(filepath, 'output.json'), 'utf8'));
-        var input = remark().parse(read(join(filepath, 'input.md'), 'utf-8'));
+        var input = remark().use(remarkAttr).parse(read(join(filepath, 'input.md'), 'utf-8'));
         var config = join(filepath, 'config.json');
         var result;
 


### PR DESCRIPTION
A node may have `hProperties.id`set by another plugin (i.e. remark-slug, remark-attr).  If an id exists in the `hProperties` use that as the value for the slug.   The value is still run though `slugs.slug` to dedup.