### PR TITLE
Update remark 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Yields:
   map: 
    { type: 'list',
      ordered: false,
-     children: [ { type: 'listItem', loose: true, children: [Object] } ] } }
+     children: [ { type: 'listItem', loose: true, children: [Array] } ] } }
 ```
 
 ## API

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function toc(node, options) {
     var result = search(node, heading, settings.maxDepth || 6);
     var map = result.map;
 
-    result.map = map.length ? contents(map, settings.tight) : null;
+    result.map = map.length === 0 ? null : contents(map, settings.tight);
 
     /* No given heading */
     if (!heading) {

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -82,6 +82,21 @@ function insert(node, parent, tight) {
     * Properly style list-items with new lines.
     */
 
+    parent.spread = !tight;
+
+    if (parent.type === LIST && parent.spread) {
+        parent.spread = false;
+        index = -1;
+
+        while (++index < length) {
+            if (children[index].children.length > 1) {
+                parent.spread = true;
+                break;
+            }
+        }
+    }
+
+    // To do: remove `loose` in next major release.
     if (parent.type === LIST_ITEM) {
         parent.loose = tight ? false : children.length > 1;
     } else {

--- a/lib/list-item.js
+++ b/lib/list-item.js
@@ -20,7 +20,9 @@ var LIST_ITEM = 'listItem';
 function listItem() {
     return {
         type: LIST_ITEM,
+        // To do: remove `loose` in next major.
         loose: false,
+        spread: false,
         children: []
     };
 }

--- a/lib/list.js
+++ b/lib/list.js
@@ -21,6 +21,7 @@ function list() {
     return {
         type: LIST,
         ordered: false,
+        spread: false,
         children: []
     };
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "browserify": "^16.2.1",
     "esmangle": "^1.0.1",
     "istanbul": "^0.4.4",
-    "remark-attr": "^0.6.2",
+    "remark-attr": "^0.7.0",
     "remark": "^10.0.0",
     "remark-cli": "^6.0.0",
     "remark-comment-config": "^5.0.0",
@@ -52,7 +52,7 @@
     "remark-usage": "^6.0.0",
     "remark-validate-links": "^7.0.0",
     "tape": "^4.6.0",
-    "xo": "^0.21.1"
+    "xo": "^0.23.0"
   },
   "xo": {
     "space": 4,

--- a/test/fixtures/custom-heading/output.json
+++ b/test/fixtures/custom-heading/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/deep-headings/output.json
+++ b/test/fixtures/deep-headings/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -58,6 +62,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/image-in-link-in-heading/output.json
+++ b/test/fixtures/image-in-link-in-heading/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/maximum-depth-1/output.json
+++ b/test/fixtures/maximum-depth-1/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": false,
     "children": [
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/maximum-depth-3/output.json
+++ b/test/fixtures/maximum-depth-3/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": true,
             "children": [
               {
                 "type": "listItem",
                 "loose": true,
+                "spread": true,
                 "children": [
                   {
                     "type": "paragraph",
@@ -52,10 +56,12 @@
                   {
                     "type": "list",
                     "ordered": false,
+                    "spread": false,
                     "children": [
                       {
                         "type": "listItem",
                         "loose": false,
+                        "spread": false,
                         "children": [
                           {
                             "type": "paragraph",

--- a/test/fixtures/maximum-depth-6/output.json
+++ b/test/fixtures/maximum-depth-6/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": true,
             "children": [
               {
                 "type": "listItem",
                 "loose": true,
+                "spread": true,
                 "children": [
                   {
                     "type": "paragraph",
@@ -52,10 +56,12 @@
                   {
                     "type": "list",
                     "ordered": false,
+                    "spread": true,
                     "children": [
                       {
                         "type": "listItem",
                         "loose": true,
+                        "spread": true,
                         "children": [
                           {
                             "type": "paragraph",
@@ -76,10 +82,12 @@
                           {
                             "type": "list",
                             "ordered": false,
+                            "spread": true,
                             "children": [
                               {
                                 "type": "listItem",
                                 "loose": true,
+                                "spread": true,
                                 "children": [
                                   {
                                     "type": "paragraph",
@@ -100,10 +108,12 @@
                                   {
                                     "type": "list",
                                     "ordered": false,
+                                    "spread": true,
                                     "children": [
                                       {
                                         "type": "listItem",
                                         "loose": true,
+                                        "spread": true,
                                         "children": [
                                           {
                                             "type": "paragraph",
@@ -124,10 +134,12 @@
                                           {
                                             "type": "list",
                                             "ordered": false,
+                                            "spread": false,
                                             "children": [
                                               {
                                                 "type": "listItem",
                                                 "loose": false,
+                                                "spread": false,
                                                 "children": [
                                                   {
                                                     "type": "paragraph",

--- a/test/fixtures/normal-attr/output.json
+++ b/test/fixtures/normal-attr/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/normal-literal-dashes/output.json
+++ b/test/fixtures/normal-literal-dashes/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -58,6 +62,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/normal-nesting-inverted/output.json
+++ b/test/fixtures/normal-nesting-inverted/output.json
@@ -4,18 +4,22 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -42,6 +46,7 @@
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -62,10 +67,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -92,6 +99,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/normal-singular/output.json
+++ b/test/fixtures/normal-singular/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/normal-toc/output.json
+++ b/test/fixtures/normal-toc/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/normal/output.json
+++ b/test/fixtures/normal/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/slug-for-images-and-links/output.json
+++ b/test/fixtures/slug-for-images-and-links/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": true,
     "children": [
       {
         "type": "listItem",
         "loose": true,
+        "spread": true,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -80,6 +85,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/tight/output.json
+++ b/test/fixtures/tight/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": false,
     "children": [
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",
@@ -28,10 +30,12 @@
           {
             "type": "list",
             "ordered": false,
+            "spread": false,
             "children": [
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -54,6 +58,7 @@
               {
                 "type": "listItem",
                 "loose": false,
+                "spread": false,
                 "children": [
                   {
                     "type": "paragraph",
@@ -74,10 +79,12 @@
                   {
                     "type": "list",
                     "ordered": false,
+                    "spread": false,
                     "children": [
                       {
                         "type": "listItem",
                         "loose": false,
+                        "spread": false,
                         "children": [
                           {
                             "type": "paragraph",
@@ -100,6 +107,7 @@
                       {
                         "type": "listItem",
                         "loose": false,
+                        "spread": false,
                         "children": [
                           {
                             "type": "paragraph",
@@ -130,6 +138,7 @@
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",

--- a/test/fixtures/unicode/output.json
+++ b/test/fixtures/unicode/output.json
@@ -4,10 +4,12 @@
   "map": {
     "type": "list",
     "ordered": false,
+    "spread": false,
     "children": [
       {
         "type": "listItem",
         "loose": false,
+        "spread": false,
         "children": [
           {
             "type": "paragraph",


### PR DESCRIPTION
This commit adds support for `spread`, introduced in remark@10.0.0,
which is replacing `loose`.  This PR is backwards compatible, and thus
can be released as a minor.

See: <remarkjs/remark@aab3c3e>

P.S. I checked with `remark-toc` whether this works, and it does!